### PR TITLE
bump version number

### DIFF
--- a/esp_flasher_app.h
+++ b/esp_flasher_app.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#define ESP_FLASHER_APP_VERSION "v1.4"
+#define ESP_FLASHER_APP_VERSION "v1.7"
 
 typedef struct EspFlasherApp EspFlasherApp;
 


### PR DESCRIPTION
after updating the app i was confused as to why the version in the about page did not change to reflect the [latest release tag](https://github.com/0xchocolate/flipperzero-esp-flasher/releases/latest), this should fix that :p